### PR TITLE
chore(ci): pre-commit + coverage + Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,16 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
 
-      - name: Run tests
-        run: pytest -q
+      - name: Run tests with coverage
+        run: |
+          pytest -q --cov=app --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          flags: unittests
+          fail_ci_if_error: false
 
   lint:
     name: lint (ruff)
@@ -88,6 +96,22 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     timeout-minutes: 10
+
+  precommit:
+    name: pre-commit
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure --color always
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-added-large-files
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.13.0
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - pydantic==2.8.2
+          - numpy==1.26.4
+          - pandas==2.2.2
+        args: ["app"]
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # JP Stocks ML Forecaster
 
+[![CI](https://github.com/kaenozu/trade/actions/workflows/ci.yml/badge.svg)](https://github.com/kaenozu/trade/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/kaenozu/trade/branch/main/graph/badge.svg)](https://codecov.io/gh/kaenozu/trade)
+
 日本株の終値データから機械学習で短期リターンを予測し、予測区間内での「買い・売り」タイミングを提示する FastAPI アプリです。
 
 ## セットアップ

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ httpx==0.27.0
 pytest==8.3.1
 pytest-asyncio==0.23.7
 python-multipart==0.0.9
+pytest-cov==5.0.0


### PR DESCRIPTION
Adds developer safeguards and visibility:\n\n- pre-commit: ruff (format + lint) & mypy, plus basic file hygiene\n- tests: run with coverage and upload to Codecov\n- README: CI and coverage badges\n\nNotes:\n- pre-commit job is non-blocking initially; enable locally via: pre-commit install\n- For private repos, set CODECOV_TOKEN secret to enable uploads\n