### PR TITLE
chore: /healthz, .env.example, PR/Issue templates, Dependabot auto-merge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Observability
+METRICS_ENABLED=1
+# Sentry (optional)
+# SENTRY_DSN=https://public-key@o000000.ingest.sentry.io/0
+# SENTRY_TRACES_SAMPLE_RATE=0.0
+# SENTRY_PROFILES_SAMPLE_RATE=0.0
+# SENTRY_ENV=dev
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+---
+
+### Describe the bug
+
+### To Reproduce
+Steps to reproduce the behavior:
+1. ...
+
+### Expected behavior
+
+### Screenshots / Logs
+
+### Environment
+- OS:
+- Python:
+- App version / commit:
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+### Problem / Opportunity
+
+### Proposed solution
+
+### Alternatives considered
+
+### Additional context
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- What is the change? Why? -->
+
+## Changes
+
+- [ ] Code changes are documented in README or inline where relevant
+- [ ] Tests pass (pytest)
+- [ ] Lint passes locally (ruff) or violations are justified
+- [ ] Type-check passes locally (mypy) or ignored with reason
+
+## Checklist
+
+- [ ] No secrets or tokens committed
+- [ ] If behavior changes, added/updated tests
+- [ ] If dependencies changed, ran `pip-audit`
+

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch updates
+        if: contains(steps.metadata.outputs.update-type, 'version-update:semver-patch')
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash
+

--- a/README.md
+++ b/README.md
@@ -30,11 +30,15 @@ powershell -ExecutionPolicy Bypass -File scripts/dev.ps1 -Port 8000
 
 ブラウザで `http://127.0.0.1:8000/` を開き、銘柄（例: `7203.T`）を入力して実行します。
 
+ヘルスチェック: `GET /healthz` は `{ "status": "ok" }` を返します。
+
 ## 運用/監視（オプション）
 
 - メトリクス: `/metrics` にPrometheusメトリクスを公開（デフォルト有効）。無効化は `METRICS_ENABLED=0`。
 - エラートラッキング: Sentryを有効化する場合は `SENTRY_DSN` を環境変数で設定。
   - 例: `SENTRY_TRACES_SAMPLE_RATE=0.1`（APM任意）、`SENTRY_PROFILES_SAMPLE_RATE=0.1`、`SENTRY_ENV=prod`。
+
+環境変数の例は `.env.example` を参照してください。
 
 ## リリース
 

--- a/app/main.py
+++ b/app/main.py
@@ -178,6 +178,11 @@ def predict(req: PredictionRequest):
         trade_plan=TradePlan(**trade),
         predictions=preds,
     )
+
+
+@app.get("/healthz")
+def healthz():
+    return {"status": "ok"}
 @app.get("/tickers")
 def tickers(q: Optional[str] = None):
     return list_jp_tickers(query=q)


### PR DESCRIPTION
Developer productivity and ops hygiene improvements.\n\n- API: add /healthz endpoint\n- Docs: add .env.example\n- Community: PR & Issue templates\n- Maintenance: auto-enable Dependabot auto-merge for patch updates\n\nNo breaking changes; tests pass locally.