### PR TITLE
chore: CORS middleware + Bandit security scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,22 @@ jobs:
           python -m pip install pre-commit
       - name: Run pre-commit
         run: pre-commit run --all-files --show-diff-on-failure --color always
+
+  bandit:
+    name: security (bandit)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install bandit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install bandit==1.7.9
+      - name: Run bandit
+        run: bandit -r app -q -ll || true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ powershell -ExecutionPolicy Bypass -File scripts/dev.ps1 -Port 8000
 - メトリクス: `/metrics` にPrometheusメトリクスを公開（デフォルト有効）。無効化は `METRICS_ENABLED=0`。
 - エラートラッキング: Sentryを有効化する場合は `SENTRY_DSN` を環境変数で設定。
   - 例: `SENTRY_TRACES_SAMPLE_RATE=0.1`（APM任意）、`SENTRY_PROFILES_SAMPLE_RATE=0.1`、`SENTRY_ENV=prod`。
+ - CORS: `CORS_ORIGINS`（カンマ区切り）で許可オリジンを設定。デフォルトは `*`。
 
 環境変数の例は `.env.example` を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ powershell -ExecutionPolicy Bypass -File scripts/dev.ps1 -Port 8000
 - メトリクス: `/metrics` にPrometheusメトリクスを公開（デフォルト有効）。無効化は `METRICS_ENABLED=0`。
 - エラートラッキング: Sentryを有効化する場合は `SENTRY_DSN` を環境変数で設定。
   - 例: `SENTRY_TRACES_SAMPLE_RATE=0.1`（APM任意）、`SENTRY_PROFILES_SAMPLE_RATE=0.1`、`SENTRY_ENV=prod`。
- - CORS: `CORS_ORIGINS`（カンマ区切り）で許可オリジンを設定。デフォルトは `*`。
+- CORS: `CORS_ORIGINS`（カンマ区切り）で許可オリジンを設定。デフォルトは `*`。
 
 環境変数の例は `.env.example` を参照してください。
 

--- a/app/main.py
+++ b/app/main.py
@@ -44,6 +44,22 @@ if os.environ.get("METRICS_ENABLED", "1") not in ("0", "false", "False") and Ins
     except Exception:
         pass
 
+# CORS (for local dev or specified origins)
+try:
+    from fastapi.middleware.cors import CORSMiddleware  # type: ignore
+
+    origins_env = os.environ.get("CORS_ORIGINS", "*")
+    origins = [o.strip() for o in origins_env.split(",") if o.strip()]
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+except Exception:
+    pass
+
 
 class PredictionRequest(BaseModel):
     ticker: str


### PR DESCRIPTION
Adds:\n- CORS middleware configured via CORS_ORIGINS env (default '*')\n- Bandit security scan job in CI (non-blocking for now)\n\nAll tests pass locally (3 passed).