### PR TITLE
chore: add .gitignore and untrack uvicorn logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Virtual environments
+.venv/
+venv/
+
+# Python cache
+__pycache__/
+*.py[cod]
+*.pyo
+.pytest_cache/
+
+# IDE/editor
+.idea/
+.vscode/
+*.swp
+
+# Logs and runtime outputs
+*.log
+uvicorn.*.log
+tmp_openapi_*.json
+logs/
+cache/
+
+# Models and large artifacts
+models/*.joblib
+
+# Build
+dist/
+build/
+*.egg-info/

--- a/uvicorn.err.log
+++ b/uvicorn.err.log
@@ -1,8 +1,0 @@
-C:\Users\neoen\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\sklearn\experimental\enable_hist_gradient_boosting.py:16: UserWarning: Since version 1.0, it is not needed to import enable_hist_gradient_boosting anymore. HistGradientBoostingClassifier and HistGradientBoostingRegressor are now stable and can be normally imported from sklearn.ensemble.
-  warnings.warn(
-INFO:     Started server process [103160]
-INFO:     Waiting for application startup.
-INFO:     Application startup complete.
-ERROR:    [Errno 10048] error while attempting to bind on address ('127.0.0.1', 8000): [winerror 10048] 通常、各ソケット アドレスに対してプロトコル、ネットワーク アドレス、またはポートのどれか 1 つのみを使用できます。
-INFO:     Waiting for application shutdown.
-INFO:     Application shutdown complete.


### PR DESCRIPTION
- Add `.gitignore` to exclude venv, caches, logs, models
- Stop tracking `uvicorn.err.log` and `uvicorn.out.log`
- Housekeeping only; no runtime behavior changes